### PR TITLE
Checkout with full git history

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # <-- clone with complete history
       - name: S3 Backup
         uses: peter-evans/s3-backup@v1
         env:


### PR DESCRIPTION
actions/checkout@v2 creates a shallow clone by default

I've just found out that actions/checkout@v2 only creates a shallow clone by default, so git history is not being backed up without this addition.